### PR TITLE
REFLESH_TABLE の操作があった際の処理をRMUに実装

### DIFF
--- a/room/lambda/room-rmu/main.go
+++ b/room/lambda/room-rmu/main.go
@@ -14,16 +14,18 @@ import (
 var client *dynamodb.Client
 
 func HandleRequest(request events.DynamoDBEvent) error {
+	roomService := service.NewRoomService(
+		repository.NewDynamoRoomRepository(client),
+	)
+
 	for _, event := range request.Records {
 		if event.EventName == "REMOVE" {
 			continue
 		}
 
-		err := service.NewRoomService(
-			repository.NewDynamoRoomRepository(client),
-		).SaveRoom(
-			event.Change.NewImage,
+		err := roomService.SaveRoom(
 			context.TODO(),
+			event.Change.NewImage,
 		)
 		if err != nil {
 			return err

--- a/room/lambda/room-rmu/model/room.go
+++ b/room/lambda/room-rmu/model/room.go
@@ -8,7 +8,7 @@ import (
 type RoomRepository interface {
 	Save(context context.Context, room *Room) error
 	FindActiveUsers(context context.Context, roomId string) ([]Room, error)
-	UpdateActiveUsersStatus(context context.Context, rooms *[]Room, status Status) error
+	UpdateActiveUserStatus(context context.Context, room *Room, status Status) error
 }
 
 type Status string

--- a/room/lambda/room-rmu/model/room.go
+++ b/room/lambda/room-rmu/model/room.go
@@ -7,6 +7,8 @@ import (
 
 type RoomRepository interface {
 	Save(context context.Context, room *Room) error
+	FindActiveUsers(context context.Context, roomId string) ([]Room, error)
+	UpdateActiveUsersStatus(context context.Context, rooms *[]Room, status Status) error
 }
 
 type Status string

--- a/room/lambda/room-rmu/model/room.go
+++ b/room/lambda/room-rmu/model/room.go
@@ -1,15 +1,40 @@
 package model
 
-import "context"
+import (
+	"context"
+	"fmt"
+)
 
 type RoomRepository interface {
 	Save(context context.Context, room *Room) error
 }
 
+type Status string
+
+const (
+	StatusChoosing = Status("CHOOSING")
+	StatusChoosed  = Status("CHOOSED")
+	StatusLeaved   = Status("LEAVED")
+)
+
+func NewStatus(s string) (Status, error) {
+	status := Status(s)
+	switch status {
+	case StatusChoosing, StatusChoosed, StatusLeaved:
+		return status, nil
+	default:
+		return "", fmt.Errorf("unexpected status string: %s", s)
+	}
+}
+
+func (status Status) String() string {
+	return string(status)
+}
+
 type Room struct {
 	RoomId     string `dynamodbav:"room_id" json:"room_id"`
 	UserId     string `dynamodbav:"user_id" json:"user_id"`
-	Status     string `dynamodbav:"status" json:"status"`
+	Status     Status `dynamodbav:"status" json:"status"`
 	PickedCard string `dynamodbav:"picked_card" json:"picked_card"`
 	OperatedAt string `dynamodbav:"operated_at" json:"operated_at"`
 }

--- a/room/lambda/room-rmu/model/room_factory.go
+++ b/room/lambda/room-rmu/model/room_factory.go
@@ -3,7 +3,7 @@ package model
 import "fmt"
 
 func CreateRoom(operation *Operation) (*Room, error) {
-	status, err := createStatusStr(operation.OpType)
+	status, err := createStatus(operation.OpType)
 	if err != nil {
 		return nil, err
 	}
@@ -22,14 +22,14 @@ func CreateRoom(operation *Operation) (*Room, error) {
 	}, nil
 }
 
-func createStatusStr(opType OpType) (string, error) {
+func createStatus(opType OpType) (Status, error) {
 	switch opType {
 	case OpenRoom, Joined, RefreshTable:
-		return "CHOOSING", nil
+		return NewStatus("CHOOSING")
 	case Leaved:
-		return "LEAVED", nil
+		return NewStatus("LEAVED")
 	case Picked:
-		return "CHOOSED", nil
+		return NewStatus("CHOOSED")
 	default:
 		return "", fmt.Errorf("unexpected op_type: %v", opType)
 	}

--- a/room/lambda/room-rmu/model/room_factory_test.go
+++ b/room/lambda/room-rmu/model/room_factory_test.go
@@ -21,7 +21,7 @@ func TestCreateRoomOpTypeJoined(t *testing.T) {
 	if actual.UserId != "2" {
 		t.Fatalf("unexpected UserId: %s", actual.UserId)
 	}
-	if actual.Status != "CHOOSING" {
+	if actual.Status.String() != "CHOOSING" {
 		t.Fatalf("unexpected Status: %s", actual.Status)
 	}
 	if actual.PickedCard != "" {
@@ -49,7 +49,7 @@ func TestCreateRoomOpTypeleaved(t *testing.T) {
 	if actual.UserId != "2" {
 		t.Fatalf("unexpected UserId: %s", actual.UserId)
 	}
-	if actual.Status != "LEAVED" {
+	if actual.Status.String() != "LEAVED" {
 		t.Fatalf("unexpected Status: %s", actual.Status)
 	}
 	if actual.PickedCard != "" {
@@ -78,7 +78,7 @@ func TestCreateRoomOpTypePicked(t *testing.T) {
 	if actual.UserId != "2" {
 		t.Fatalf("unexpected UserId: %s", actual.UserId)
 	}
-	if actual.Status != "CHOOSED" {
+	if actual.Status.String() != "CHOOSED" {
 		t.Fatalf("unexpected Status: %s", actual.Status)
 	}
 	if actual.PickedCard != "5" {

--- a/room/lambda/room-rmu/repository/dynamo_client.go
+++ b/room/lambda/room-rmu/repository/dynamo_client.go
@@ -10,8 +10,22 @@ type DynamoDBPutAPI interface {
 	PutItem(ctx context.Context,
 		params *dynamodb.PutItemInput,
 		optFns ...func(*dynamodb.Options)) (*dynamodb.PutItemOutput, error)
+	Query(ctx context.Context,
+		params *dynamodb.QueryInput,
+		optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
+	TransactWriteItems(ctx context.Context,
+		params *dynamodb.TransactWriteItemsInput,
+		optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
 }
 
 func PutItem(c context.Context, api DynamoDBPutAPI, input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
 	return api.PutItem(c, input)
+}
+
+func Query(c context.Context, api DynamoDBPutAPI, input *dynamodb.QueryInput) (*dynamodb.QueryOutput, error) {
+	return api.Query(c, input)
+}
+
+func TransactWriteItems(c context.Context, api DynamoDBPutAPI, input *dynamodb.TransactWriteItemsInput) (*dynamodb.TransactWriteItemsOutput, error) {
+	return api.TransactWriteItems(c, input)
 }

--- a/room/lambda/room-rmu/repository/dynamo_client.go
+++ b/room/lambda/room-rmu/repository/dynamo_client.go
@@ -13,9 +13,9 @@ type DynamoDBPutAPI interface {
 	Query(ctx context.Context,
 		params *dynamodb.QueryInput,
 		optFns ...func(*dynamodb.Options)) (*dynamodb.QueryOutput, error)
-	TransactWriteItems(ctx context.Context,
-		params *dynamodb.TransactWriteItemsInput,
-		optFns ...func(*dynamodb.Options)) (*dynamodb.TransactWriteItemsOutput, error)
+	UpdateItem(ctx context.Context,
+		params *dynamodb.UpdateItemInput,
+		optFns ...func(*dynamodb.Options)) (*dynamodb.UpdateItemOutput, error)
 }
 
 func PutItem(c context.Context, api DynamoDBPutAPI, input *dynamodb.PutItemInput) (*dynamodb.PutItemOutput, error) {
@@ -26,6 +26,6 @@ func Query(c context.Context, api DynamoDBPutAPI, input *dynamodb.QueryInput) (*
 	return api.Query(c, input)
 }
 
-func TransactWriteItems(c context.Context, api DynamoDBPutAPI, input *dynamodb.TransactWriteItemsInput) (*dynamodb.TransactWriteItemsOutput, error) {
-	return api.TransactWriteItems(c, input)
+func UpdateItem(c context.Context, api DynamoDBPutAPI, input *dynamodb.UpdateItemInput) (*dynamodb.UpdateItemOutput, error) {
+	return api.UpdateItem(c, input)
 }

--- a/room/lambda/room-rmu/repository/dynamo_room_repository.go
+++ b/room/lambda/room-rmu/repository/dynamo_room_repository.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
+	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
 	"github.com/yuizho/salon/room/lambda/room-rmu/model"
 )
 
@@ -27,6 +28,68 @@ func (repos *DynamoRoomRepository) Save(context context.Context, room *model.Roo
 		TableName: aws.String("room"),
 		Item:      roomItem,
 	})
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (repos *DynamoRoomRepository) FindActiveUsers(context context.Context, roomId string) ([]model.Room, error) {
+	result, err := Query(context, repos.client, &dynamodb.QueryInput{
+		TableName:              aws.String("room"),
+		KeyConditionExpression: aws.String("room_id = :room_id"),
+		FilterExpression:       aws.String("#status <> :status"),
+		ExpressionAttributeNames: map[string]string{
+			"#status": "status",
+		},
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":room_id": &types.AttributeValueMemberS{Value: roomId},
+			":status":  &types.AttributeValueMemberS{Value: "LEAVED"},
+		},
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var rooms []model.Room
+	for _, item := range result.Items {
+		room := model.Room{}
+		attributevalue.UnmarshalMap(item, &room)
+		rooms = append(rooms, room)
+	}
+
+	return rooms, nil
+}
+
+func (repos *DynamoRoomRepository) UpdateActiveUsersStatus(context context.Context, rooms *[]model.Room, status model.Status) error {
+	var requests []types.TransactWriteItem
+	for _, room := range *rooms {
+		requests = append(requests, types.TransactWriteItem{
+			Update: &types.Update{
+				TableName: aws.String("room"),
+				Key: map[string]types.AttributeValue{
+					"room_id": &types.AttributeValueMemberS{Value: room.RoomId},
+					"user_id": &types.AttributeValueMemberS{Value: room.UserId},
+				},
+				UpdateExpression:    aws.String("SET #status = :status, operated_at = :operated_at REMOVE picked_card"),
+				ConditionExpression: aws.String("#status <> :condition_status"),
+				ExpressionAttributeNames: map[string]string{
+					"#status": "status",
+				},
+				ExpressionAttributeValues: map[string]types.AttributeValue{
+					":status":           &types.AttributeValueMemberS{Value: status.String()},
+					":operated_at":      &types.AttributeValueMemberS{Value: room.OperatedAt},
+					":condition_status": &types.AttributeValueMemberS{Value: "LEAVED"},
+				},
+			},
+		})
+	}
+
+	_, err := TransactWriteItems(context, repos.client, &dynamodb.TransactWriteItemsInput{
+		TransactItems: requests,
+	})
+
 	if err != nil {
 		return err
 	}

--- a/room/lambda/room-rmu/service/room_service.go
+++ b/room/lambda/room-rmu/service/room_service.go
@@ -23,13 +23,23 @@ func (service *RoomService) SaveRoom(attrs map[string]events.DynamoDBAttributeVa
 	}
 	log.Printf("Operation: %#v", operation)
 
+	switch operation.OpType {
+	case model.RefreshTable:
+		// TODO: when opType is refresh_table update all user record of the room
+	default:
+		return service.saveUserState(operation, context)
+	}
+
+	return nil
+}
+
+func (service *RoomService) saveUserState(operation *model.Operation, context context.Context) error {
 	room, err := model.CreateRoom(operation)
 	if err != nil {
 		return err
 	}
 	log.Printf("Room: %#v", room)
 
-	// TODO: when opType is refresh_table update all user record of the room
 	err = service.repository.Save(context, room)
 	if err != nil {
 		return err

--- a/room/lambda/room-rmu/service/room_service.go
+++ b/room/lambda/room-rmu/service/room_service.go
@@ -16,7 +16,7 @@ func NewRoomService(repository model.RoomRepository) *RoomService {
 	return &RoomService{repository: repository}
 }
 
-func (service *RoomService) SaveRoom(attrs map[string]events.DynamoDBAttributeValue, context context.Context) error {
+func (service *RoomService) SaveRoom(context context.Context, attrs map[string]events.DynamoDBAttributeValue) error {
 	operation, err := model.NewOperation(attrs)
 	if err != nil {
 		return err
@@ -27,23 +27,18 @@ func (service *RoomService) SaveRoom(attrs map[string]events.DynamoDBAttributeVa
 	case model.RefreshTable:
 		// TODO: when opType is refresh_table update all user record of the room
 	default:
-		return service.saveUserState(operation, context)
+		return service.saveUserState(context, operation)
 	}
 
 	return nil
 }
 
-func (service *RoomService) saveUserState(operation *model.Operation, context context.Context) error {
+func (service *RoomService) saveUserState(context context.Context, operation *model.Operation) error {
 	room, err := model.CreateRoom(operation)
 	if err != nil {
 		return err
 	}
 	log.Printf("Room: %#v", room)
 
-	err = service.repository.Save(context, room)
-	if err != nil {
-		return err
-	}
-
-	return nil
+	return service.repository.Save(context, room)
 }

--- a/room/lambda/room-rmu/service/room_service_test.go
+++ b/room/lambda/room-rmu/service/room_service_test.go
@@ -1,0 +1,59 @@
+package service
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/aws/aws-lambda-go/events"
+	"github.com/yuizho/salon/room/lambda/room-rmu/model"
+)
+
+type TestRepos struct {
+}
+
+func (repos *TestRepos) Save(context context.Context, room *model.Room) error {
+	return nil
+}
+func (repos *TestRepos) FindActiveUsers(context context.Context, roomId string) ([]model.Room, error) {
+	return []model.Room{
+		{
+			RoomId:     "1",
+			UserId:     "1",
+			Status:     model.Status("CHOOSING"),
+			OperatedAt: "2022-10-10T13:50:40Z",
+		},
+		{
+			RoomId:     "1",
+			UserId:     "2",
+			Status:     model.Status("CHOOSING"),
+			OperatedAt: "2022-10-10T13:50:40Z",
+		},
+	}, nil
+}
+func (repos *TestRepos) UpdateActiveUserStatus(context context.Context, room *model.Room, status model.Status) error {
+	// part of update is failed
+	if room.UserId == "2" {
+		return fmt.Errorf("some error")
+	}
+	return nil
+}
+
+func TestRefleshPoker(t *testing.T) {
+	input := make(map[string]events.DynamoDBAttributeValue)
+	input["event_id"] = events.NewStringAttribute("9999")
+	input["room_id"] = events.NewStringAttribute("1")
+	input["user_id"] = events.NewStringAttribute("2")
+	input["op_type"] = events.NewStringAttribute("REFRESH_TABLE")
+	input["picked_card"] = events.NewNullAttribute()
+	input["operated_at"] = events.NewStringAttribute("2022-10-10T13:50:40Z")
+
+	err := NewRoomService(&TestRepos{}).SaveRoom(
+		context.TODO(),
+		input,
+	)
+
+	if err != nil {
+		t.Fatalf("failed to update user status: %v", err)
+	}
+}

--- a/room/lib/room-stack.ts
+++ b/room/lib/room-stack.ts
@@ -106,7 +106,7 @@ export class RoomStack extends Stack {
         retryAttempts: 3,
       })
     );
-    roomTable.grantWriteData(roomRMUFunction);
+    roomTable.grantReadWriteData(roomRMUFunction);
 
     const mutatePokerFunction = new lambdaGo.GoFunction(this, "mutate-poker", {
       functionName: "MutatePoker",

--- a/room/lib/room-stack.ts
+++ b/room/lib/room-stack.ts
@@ -43,6 +43,7 @@ export class RoomStack extends Stack {
     // TODO: operation API
     // TODO: log
     // TODO: Xray
+    //  TODO: WAF
     const roomAPI = new appsync.GraphqlApi(this, "RoomAPI", {
       name: "RoomAPI",
       schema: appsync.Schema.fromAsset("appsync/room-api/schema.graphql"),


### PR DESCRIPTION
## overview
https://github.com/yuizho/salon/issues/1#issuecomment-1107332442 で記述していた処理を実装した。

`REFRESH_TABLE` はその部屋のアクティブなユーザのステータスを `CHOOSING` に変える操作なので、他の操作と違って他のユーザの操作と競合する可能性がある。

ケアしないといけないのは、以下のケース
1. ユーザAがREFRESH_TABLEの操作が行い、更新対象のアクティブな(LEAVEDでない)ユーザ情報をテーブルから取得処理が実行される
2. ユーザBが部屋から退出しており、絶妙なタイミングでユーザBのSTATUSがLEAVEDに更新される
3. ユーザAのREFRESH_TABLEの更新処理が実行されるが、ユーザBのステータスは2.の操作でLEAVEDになっているので更新してはいけない

Transaction使ったり、BatchWriteで更新することを検討したが、結局REFRESH_TABLEの操作で `LEAVED` のステータスが更新されなければ良いので、UpdateItemで繰り返し実行する実装になった。

- 最初Transactionで実装しようとしたが、他のユーザの退出操作によるPutItemが `TransactionConflictException` で失敗したりするようなのでやめた
  - https://docs.aws.amazon.com/ja_jp/amazondynamodb/latest/developerguide/transaction-apis.html#transaction-conflict-handling 
- BatchWriteを使いたかったが、conditionの指定ができなかった :cry: 
  - https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html 

## reference
実装にあたって書き残したメモ
- aws-sdk-go-v2によるDynamoDBの操作
  - https://scrapbox.io/yuizho-tech/aws-sdk-go-v2%E3%81%AB%E3%82%88%E3%82%8BDynamoDB%E3%81%AE%E6%93%8D%E4%BD%9C
- DynamoDBの更新処理について
  - そもそもDynamoDBで複数レコードを一気にUpdateできないことからわかってなかった
  - https://scrapbox.io/yuizho-tech/DynamoDB%E3%81%AE%E6%9B%B4%E6%96%B0%E5%87%A6%E7%90%86%E3%81%AB%E3%81%A4%E3%81%84%E3%81%A6