### PR TITLE
RMUにroomの状態チェックを実装

### DIFF
--- a/room/lambda/room-rmu/model/room.go
+++ b/room/lambda/room-rmu/model/room.go
@@ -8,7 +8,8 @@ import (
 type RoomRepository interface {
 	Save(context context.Context, room *Room) error
 	FindActiveUsers(context context.Context, roomId string) (*[]Room, error)
-	UpdateActiveUserStatus(context context.Context, room *Room, status Status) error
+	UpdateActiveUser(context context.Context, room *Room) error
+	ExistRoom(context context.Context, roomId string) (bool, error)
 }
 
 type Status string
@@ -39,4 +40,16 @@ type Room struct {
 	Status     Status `dynamodbav:"status" json:"status"`
 	PickedCard string `dynamodbav:"picked_card" json:"picked_card"`
 	OperatedAt string `dynamodbav:"operated_at" json:"operated_at"`
+}
+
+func (room *Room) RefreshPokerTable(operatedAt string) error {
+	choosing, err := NewStatus("CHOOSING")
+	if err != nil {
+		return err
+	}
+
+	room.PickedCard = ""
+	room.Status = choosing
+	room.OperatedAt = operatedAt
+	return nil
 }

--- a/room/lambda/room-rmu/model/room.go
+++ b/room/lambda/room-rmu/model/room.go
@@ -7,7 +7,7 @@ import (
 
 type RoomRepository interface {
 	Save(context context.Context, room *Room) error
-	FindActiveUsers(context context.Context, roomId string) ([]Room, error)
+	FindActiveUsers(context context.Context, roomId string) (*[]Room, error)
 	UpdateActiveUserStatus(context context.Context, room *Room, status Status) error
 }
 

--- a/room/lambda/room-rmu/repository/dynamo_room_repository.go
+++ b/room/lambda/room-rmu/repository/dynamo_room_repository.go
@@ -35,7 +35,7 @@ func (repos *DynamoRoomRepository) Save(context context.Context, room *model.Roo
 	return nil
 }
 
-func (repos *DynamoRoomRepository) FindActiveUsers(context context.Context, roomId string) ([]model.Room, error) {
+func (repos *DynamoRoomRepository) FindActiveUsers(context context.Context, roomId string) (*[]model.Room, error) {
 	result, err := Query(context, repos.client, &dynamodb.QueryInput{
 		TableName:              aws.String("room"),
 		KeyConditionExpression: aws.String("room_id = :room_id"),
@@ -59,7 +59,7 @@ func (repos *DynamoRoomRepository) FindActiveUsers(context context.Context, room
 		rooms = append(rooms, room)
 	}
 
-	return rooms, nil
+	return &rooms, nil
 }
 
 func (repos *DynamoRoomRepository) UpdateActiveUserStatus(context context.Context, room *model.Room, status model.Status) error {

--- a/room/lambda/room-rmu/repository/dynamo_room_repository.go
+++ b/room/lambda/room-rmu/repository/dynamo_room_repository.go
@@ -62,21 +62,24 @@ func (repos *DynamoRoomRepository) FindActiveUsers(context context.Context, room
 	return &rooms, nil
 }
 
-func (repos *DynamoRoomRepository) UpdateActiveUserStatus(context context.Context, room *model.Room, status model.Status) error {
+func (repos *DynamoRoomRepository) UpdateActiveUser(context context.Context, room *model.Room) error {
 	_, err := UpdateItem(context, repos.client, &dynamodb.UpdateItemInput{
 		TableName: aws.String("room"),
 		Key: map[string]types.AttributeValue{
 			"room_id": &types.AttributeValueMemberS{Value: room.RoomId},
 			"user_id": &types.AttributeValueMemberS{Value: room.UserId},
 		},
-		UpdateExpression:    aws.String("SET #status = :status, operated_at = :operated_at REMOVE picked_card"),
-		ConditionExpression: aws.String("#status <> :condition_status"),
+		UpdateExpression:    aws.String("SET #status = :status, operated_at = :operated_at, picked_card = :picked_card"),
+		ConditionExpression: aws.String("attribute_exists(#room_id) AND attribute_exists(#user_id) AND #status <> :condition_status"),
 		ExpressionAttributeNames: map[string]string{
-			"#status": "status",
+			"#room_id": "room_id",
+			"#user_id": "user_id",
+			"#status":  "status",
 		},
 		ExpressionAttributeValues: map[string]types.AttributeValue{
-			":status":           &types.AttributeValueMemberS{Value: status.String()},
+			":status":           &types.AttributeValueMemberS{Value: room.Status.String()},
 			":operated_at":      &types.AttributeValueMemberS{Value: room.OperatedAt},
+			":picked_card":      &types.AttributeValueMemberS{Value: room.PickedCard},
 			":condition_status": &types.AttributeValueMemberS{Value: "LEAVED"},
 		},
 	})
@@ -86,4 +89,19 @@ func (repos *DynamoRoomRepository) UpdateActiveUserStatus(context context.Contex
 	}
 
 	return nil
+}
+
+func (repos *DynamoRoomRepository) ExistRoom(context context.Context, roomId string) (bool, error) {
+	result, err := Query(context, repos.client, &dynamodb.QueryInput{
+		TableName:              aws.String("room"),
+		KeyConditionExpression: aws.String("room_id = :room_id"),
+		ExpressionAttributeValues: map[string]types.AttributeValue{
+			":room_id": &types.AttributeValueMemberS{Value: roomId},
+		},
+	})
+	if err != nil {
+		return false, err
+	}
+
+	return len(result.Items) > 0, nil
 }

--- a/room/lambda/room-rmu/service/room_service.go
+++ b/room/lambda/room-rmu/service/room_service.go
@@ -108,7 +108,7 @@ func (service *RoomService) refreshPokerTable(context context.Context, operation
 	}
 
 	if !isProperUser(rooms, operation.UserId) {
-		return fmt.Errorf("unknown user id is passed: %s", operation.UserId)
+		return fmt.Errorf("passed user id is not active: %s", operation.UserId)
 	}
 
 	reqId, err := util.GetAWSRequestId(context)

--- a/room/lambda/room-rmu/service/room_service_test.go
+++ b/room/lambda/room-rmu/service/room_service_test.go
@@ -32,12 +32,15 @@ func (repos *TestRepos) FindActiveUsers(context context.Context, roomId string) 
 		},
 	}, nil
 }
-func (repos *TestRepos) UpdateActiveUserStatus(context context.Context, room *model.Room, status model.Status) error {
+func (repos *TestRepos) UpdateActiveUser(context context.Context, room *model.Room) error {
 	// part of update is failed
 	if room.UserId == "2" {
 		return fmt.Errorf("some error")
 	}
 	return nil
+}
+func (repos *TestRepos) ExistRoom(context context.Context, roomId string) (bool, error) {
+	return true, nil
 }
 
 func TestRefleshPoker(t *testing.T) {

--- a/room/lambda/room-rmu/service/room_service_test.go
+++ b/room/lambda/room-rmu/service/room_service_test.go
@@ -16,8 +16,8 @@ type TestRepos struct {
 func (repos *TestRepos) Save(context context.Context, room *model.Room) error {
 	return nil
 }
-func (repos *TestRepos) FindActiveUsers(context context.Context, roomId string) ([]model.Room, error) {
-	return []model.Room{
+func (repos *TestRepos) FindActiveUsers(context context.Context, roomId string) (*[]model.Room, error) {
+	return &[]model.Room{
 		{
 			RoomId:     "1",
 			UserId:     "1",
@@ -62,5 +62,30 @@ func TestRefleshPoker(t *testing.T) {
 
 	if err != nil {
 		t.Fatalf("failed to update user status: %v", err)
+	}
+}
+
+func TestUnexpectedUserIdPassedToRefleshPoker(t *testing.T) {
+	input := make(map[string]events.DynamoDBAttributeValue)
+	input["event_id"] = events.NewStringAttribute("9999")
+	input["room_id"] = events.NewStringAttribute("1")
+	input["user_id"] = events.NewStringAttribute("3")
+	input["op_type"] = events.NewStringAttribute("REFRESH_TABLE")
+	input["picked_card"] = events.NewNullAttribute()
+	input["operated_at"] = events.NewStringAttribute("2022-10-10T13:50:40Z")
+
+	err := NewRoomService(&TestRepos{}).SaveRoom(
+		lambdacontext.NewContext(
+			context.TODO(),
+			&lambdacontext.LambdaContext{
+				AwsRequestID:       "1",
+				InvokedFunctionArn: "3",
+			},
+		),
+		input,
+	)
+
+	if err == nil {
+		t.Fatalf("RefleshPoker is success")
 	}
 }


### PR DESCRIPTION
https://github.com/yuizho/salon/issues/1#issuecomment-1108652385
で検討した内容を実装

op_typeごとのチェック
- JOIN
  - 更新前に room_id に一致する情報がroomにあることをチェック
- LEAVE
  - 更新前に room_id, user_id に一致する情報がroomにあることをチェック (condition expressionでチェック)
- PICK
  - 更新前に room_id, user_id に一致する情報がroomにあることをチェック (condition expressionでチェック)
- REFRESH_TABLE
  - 更新前に room_id, user_id に一致する情報がroomにあることをチェック