### PR TITLE
chore: add cooldown period to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7
+
+  - package-ecosystem: "npm"
+    directory: "/backend"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Dependabotのバージョンアップデートに対して7日間のクールダウン期間（cooldown）を設定しました。
これにより、パッケージの公開から7日間はアップデートPRが作成されず、サプライチェーン攻撃や初期バグのリスクを低減します。

設定対象:
- frontend (npm)
- backend (npm)