### PR TITLE
fix: update Lambda runtime from provided.al2 to provided.al2023

### DIFF
--- a/backend/lib/room-stack.ts
+++ b/backend/lib/room-stack.ts
@@ -134,6 +134,7 @@ export class RoomStack extends Stack {
     const roomRMUFunction = new lambdaGo.GoFunction(this, 'room-rmu', {
       functionName: 'RoomRMU',
       entry: 'lambda/room-rmu',
+      runtime: lambda.Runtime.PROVIDED_AL2023,
       timeout: Duration.seconds(10),
       tracing: lambda.Tracing.ACTIVE,
     });
@@ -149,6 +150,7 @@ export class RoomStack extends Stack {
     const mutateUserFunction = new lambdaGo.GoFunction(this, 'mutate-user', {
       functionName: 'MutateUser',
       entry: 'lambda/mutate-user',
+      runtime: lambda.Runtime.PROVIDED_AL2023,
       environment: {
         ROOM_API_URL: roomAPI.graphqlUrl,
         REGION: this.region,


### PR DESCRIPTION
## Summary

- `RoomRMU` / `MutateUser` Lambda関数のランタイムを `provided.al2` から `provided.al2023` に更新
- Amazon Linux 2 は2025年6月にEOLのため対応

closes #108

## Test plan
- [ ] CDKデプロイ後、Lambda関数のランタイムが `provided.al2023` になっていることをAWSコンソールで確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)