### PR TITLE
feat: add Dependabot auto-merge for patch/minor updates to develop

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,7 @@ updates:
     directory: "/frontend"
     schedule:
       interval: "daily"
+    target-branch: "develop"
     cooldown:
       default-days: 7
 
@@ -11,5 +12,6 @@ updates:
     directory: "/backend"
     schedule:
       interval: "daily"
+    target-branch: "develop"
     cooldown:
       default-days: 7

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]' && github.base_ref == 'develop'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: fetch-metadata
+        uses: dependabot/fetch-metadata@v2
+
+      - name: Auto-merge patch and minor updates
+        if: |
+          steps.fetch-metadata.outputs.update-type == 'version-update:semver-patch' ||
+          steps.fetch-metadata.outputs.update-type == 'version-update:semver-minor'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: fetch-metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
 
       - name: Auto-merge patch and minor updates
         if: |


### PR DESCRIPTION
## Summary

- Dependabotが作成したPRのうち、patch・minorアップデートはCIパス後にdevelopへ自動squashマージ
- majorアップデートは手動マージ
- dependabot.ymlのtarget-branchをdevelopに設定

## 事前設定が必要
- [x] GitHub Settings → General → **Allow auto-merge** を有効化

🤖 Generated with [Claude Code](https://claude.com/claude-code)